### PR TITLE
Fix PTLFlowCLI compatibility with recent Lightning versions

### DIFF
--- a/ptlflow/utils/lightning/ptlflow_cli.py
+++ b/ptlflow/utils/lightning/ptlflow_cli.py
@@ -26,6 +26,7 @@ from lightning.pytorch.utilities.rank_zero import rank_zero_warn
 
 
 class PTLFlowCLI(LightningCLI):
+    parser_class = LightningArgumentParser
     def __init__(
         self,
         model_class: Optional[


### PR DESCRIPTION
# Fix PTLFlowCLI Compatibility with required Lightning Version

This PR addresses an AttributeError that occurs when running the inference script with versions of PyTorch Lightning in requirements.txt.  The error occurs because the PTLFlowCLI class is missing the parser_class attribute that is required by Lightning .

Changes Made

Added parser_class = LightningArgumentParser to the PTLFlowCLI class

Error Fixed
CopyAttributeError: 'PTLFlowCLI' object has no attribute 'parser_class'. Did you mean: 'parser_kwargs'? This fix ensures compatibility with PyTorch Lightning's current initialization process while maintaining backward compatibility.